### PR TITLE
Lower priority for favicon in URL

### DIFF
--- a/src/Favicon/Favicon.php
+++ b/src/Favicon/Favicon.php
@@ -262,14 +262,14 @@ class Favicon
                 if ($link->hasAttribute('rel') && strtolower($link->getAttribute('rel')) == 'shortcut icon') {
                     return $link->getAttribute('href');
                 }
-			}
-			foreach ($links as $link) {
-				if ($link->hasAttribute('rel') && strtolower($link->getAttribute('rel')) == 'icon') {
+            }
+            foreach ($links as $link) {
+                if ($link->hasAttribute('rel') && strtolower($link->getAttribute('rel')) == 'icon') {
                     return $link->getAttribute('href');
                 }
-			}
-			foreach ($links as $link) {
-				if ($link->hasAttribute('href') && strpos($link->getAttribute('href'), 'favicon') !== FALSE) {
+            }
+            foreach ($links as $link) {
+                if ($link->hasAttribute('href') && strpos($link->getAttribute('href'), 'favicon') !== FALSE) {
                     return $link->getAttribute('href');
                 }
             }

--- a/src/Favicon/Favicon.php
+++ b/src/Favicon/Favicon.php
@@ -261,9 +261,15 @@ class Favicon
             foreach ($links as $link) {
                 if ($link->hasAttribute('rel') && strtolower($link->getAttribute('rel')) == 'shortcut icon') {
                     return $link->getAttribute('href');
-                } elseif ($link->hasAttribute('rel') && strtolower($link->getAttribute('rel')) == 'icon') {
+                }
+			}
+			foreach ($links as $link) {
+				if ($link->hasAttribute('rel') && strtolower($link->getAttribute('rel')) == 'icon') {
                     return $link->getAttribute('href');
-                } elseif ($link->hasAttribute('href') && strpos($link->getAttribute('href'), 'favicon') !== FALSE) {
+                }
+			}
+			foreach ($links as $link) {
+				if ($link->hasAttribute('href') && strpos($link->getAttribute('href'), 'favicon') !== FALSE) {
                     return $link->getAttribute('href');
                 }
             }


### PR DESCRIPTION
Example of site that was failing: https://twitter.com/FreshRSS
It picked:
```html
<link rel="mask-icon" sizes="any"
href="https://abs.twimg.com/a/1492738903/img/t1/favicon.svg"
color="#55acee">
```
Instead of the more appropriate:
```html
<link rel="shortcut icon" href="//abs.twimg.com/favicons/favicon.ico"
type="image/x-icon">
```
Note for later: ideally, the priority should be based on a negotiation depending on the type of favicon wanted (size, image type...).