### PR TITLE
Trim slash off URL and relative paths to avoid //

### DIFF
--- a/src/Favicon/Favicon.php
+++ b/src/Favicon/Favicon.php
@@ -204,7 +204,7 @@ class Favicon
         
         // Make sure the favicon is an absolute URL.
         if( $favicon && filter_var($favicon, FILTER_VALIDATE_URL) === false ) {
-            $favicon = $url . '/' . $favicon;
+            $favicon = rtrim($url, '/') . '/' . ltrim($favicon, '/');
         }
 
         // Sometimes people lie, so check the status.


### PR DESCRIPTION
Sometimes relative paths are prefixed with /, which when combined with $url . '/' means the resulting URL will have two slashes and be invalid. This should prevent that.