### PR TITLE
Check if headers have an index 0 before accessing it

### DIFF
--- a/src/Favicon/Favicon.php
+++ b/src/Favicon/Favicon.php
@@ -97,7 +97,7 @@ class Favicon
         $loop = TRUE;
         while ($loop && $max_loop-- > 0) {
             $headers = $this->dataAccess->retrieveHeader($url);
-            if (empty($headers)) {
+            if (empty($headers) || !array_key_exists(0, $headers)) {
                 return false;
             }
             $exploded = explode(' ', $headers[0]);


### PR DESCRIPTION
Hi! :v: 

We're using your lib in Nextcloud Mail. I've recently seen Sentry reports like

```
[PHP] Undefined offset: 0 at /var/www/nextcloud/apps/mail/vendor/arthurhoaro/favicon/src/Favicon/Favicon.php#103
```

I can't trigger this manually, but it looks like in rare cases the index 0 is not set on the header array, thus leading to a warning.

Cheers