### PR TITLE
Composer: Don't define codesniffer as a runtime dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,12 +26,12 @@
   "require": {
     "php": ">=5.6",
     "ext-dom": "*",
-    "ext-fileinfo": "*",
-    "squizlabs/php_codesniffer": "^3.5"
+    "ext-fileinfo": "*"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.8",
-    "weew/helpers-filesystem": "~1.0"
+    "weew/helpers-filesystem": "~1.0",
+    "squizlabs/php_codesniffer": "^3.5"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This isn't defined anywhere as a runtime dependency.