### PR TITLE
Fix for in-page absolute favicon paths

### DIFF
--- a/src/Favicon/Favicon.php
+++ b/src/Favicon/Favicon.php
@@ -209,11 +209,9 @@ class Favicon
 
         // Make sure the favicon is an absolute URL.
         if ($favicon && filter_var($favicon, FILTER_VALIDATE_URL) === false) {
-
             // Make sure that favicons starting with "/" get concatenated with host instead of full URL
             if($favicon[0] === '/') {
-                $parsed = parse_url($url);
-                $favicon = $parsed['scheme'] . '://' . $parsed['host'] . $favicon;
+                $favicon = $this->baseUrl($url) . ltrim($favicon, '/');
             } else {
                 $favicon = rtrim($url, '/') . '/' . ltrim($favicon, '/');
             }

--- a/src/Favicon/Favicon.php
+++ b/src/Favicon/Favicon.php
@@ -151,6 +151,7 @@ class Favicon
         // Get the base URL without the path for clearer concatenations.
         $url = rtrim($this->baseUrl($this->url, true), '/');
         $original = $url;
+
         if (
             ($favicon = $this->checkCache($original, self::$TYPE_CACHE_URL)) === false
             && ! $favicon = $this->getFavicon($original, false)
@@ -208,7 +209,14 @@ class Favicon
 
         // Make sure the favicon is an absolute URL.
         if ($favicon && filter_var($favicon, FILTER_VALIDATE_URL) === false) {
-            $favicon = rtrim($url, '/') . '/' . ltrim($favicon, '/');
+
+            // Make sure that favicons starting with "/" get concatenated with host instead of full URL
+            if($favicon[0] === '/') {
+                $parsed = parse_url($url);
+                $favicon = $parsed['scheme'] . '://' . $parsed['host'] . $favicon;
+            } else {
+                $favicon = rtrim($url, '/') . '/' . ltrim($favicon, '/');
+            }
         }
 
         // Sometimes people lie, so check the status.


### PR DESCRIPTION
**Why?** Some domains return final redirects to full URL, instead of just a hostname, eg. `https://www.somehost.blabla` makes a final 301 HTTP redirect to `https://www.somehost.blabla/en/`. With a `shortcut icon` href value set to `/someicon.ico`, the library would originally attempt to fetch `https://www.somehost.blabla/en/someicon.ico`, instead of `https://www.somehost.blabla/someicon.ico`.

This was fixed in the following PR.