### PR TITLE
Fix crash when no location header is set for 302

### DIFF
--- a/src/Favicon/Favicon.php
+++ b/src/Favicon/Favicon.php
@@ -110,9 +110,13 @@ class Favicon
             switch ($status) {
                 case '301':
                 case '302':
-                    $url = isset($headers['location']) ? $headers['location'] : '';
-                    if (is_array($url)) {
-                        $url = end($url);
+                    if (isset($headers['location'])) {
+                        $url = $headers['location'];
+                        if (is_array($url)) {
+                            $url = end($url);
+                        }
+                    } else {
+                        return false;
                     }
                     break;
                 default:


### PR DESCRIPTION
Unfortunately I discovered a misconfigured server that replies with a 302 status code, but provides no `Location` header. This makes the library crash as this sets `$url` to an empty string.

Fixes nextcloud/news#2351