### PR TITLE
fix: Call Favicon::baseUrl statically

### DIFF
--- a/src/Favicon/Favicon.php
+++ b/src/Favicon/Favicon.php
@@ -152,14 +152,14 @@ class Favicon
             $this->url = $url;
         }
 
-        $url = rtrim($this->baseUrl($this->url, true), '/');
+        $url = rtrim(self::baseUrl($this->url, true), '/');
         $original = $url;
 
         if (
             ($favicon = $this->checkCache($original, self::$TYPE_CACHE_URL)) === false
             && ! $favicon = $this->getFavicon($original, false)
         ) {
-            $url = rtrim($this->endRedirect($this->baseUrl($this->url, false)), '/');
+            $url = rtrim($this->endRedirect(self::baseUrl($this->url, false)), '/');
             if (
                 ($favicon = $this->checkCache($url, self::$TYPE_CACHE_URL)) === false
                 && ! $favicon = $this->getFavicon($url)
@@ -214,7 +214,7 @@ class Favicon
         if ($favicon && filter_var($favicon, FILTER_VALIDATE_URL) === false) {
             // Make sure that favicons starting with "/" get concatenated with host instead of full URL
             if ($favicon[0] === '/') {
-                $favicon = $this->baseUrl($url) . ltrim($favicon, '/');
+                $favicon = self::baseUrl($url) . ltrim($favicon, '/');
             } else {
                 $favicon = rtrim($url, '/') . '/' . ltrim($favicon, '/');
             }

--- a/tests/Favicon/FaviconTest.php
+++ b/tests/Favicon/FaviconTest.php
@@ -106,11 +106,11 @@ class FaviconTest extends TestCase
         $invalidPrefixUrl = 'ftp://domain.tld';
         $emptyUrl = '';
 
-        $this->assertEquals(false, $fav->baseUrl($notAnUrl));
-        $this->assertEquals(false, $fav->baseUrl($notPrefixedUrl));
-        $this->assertEquals(false, $fav->baseUrl($noHostUrl));
-        $this->assertEquals(false, $fav->baseUrl($invalidPrefixUrl));
-        $this->assertEquals(false, $fav->baseUrl($emptyUrl));
+        $this->assertEquals(false, $fav::baseUrl($notAnUrl));
+        $this->assertEquals(false, $fav::baseUrl($notPrefixedUrl));
+        $this->assertEquals(false, $fav::baseUrl($noHostUrl));
+        $this->assertEquals(false, $fav::baseUrl($invalidPrefixUrl));
+        $this->assertEquals(false, $fav::baseUrl($emptyUrl));
     }
 
     /**
@@ -130,15 +130,15 @@ class FaviconTest extends TestCase
         $urlWithUnusedInfo = 'http://domain.tld/index.php?foo=bar&bar=foo#foobar';
         $urlWithPath = 'http://domain.tld/my/super/path';
 
-        $this->assertEquals(self::slash($simpleUrl), $fav->baseUrl($simpleUrl));
-        $this->assertEquals(self::slash($simpleHttpsUrl), $fav->baseUrl($simpleHttpsUrl));
-        $this->assertEquals(self::slash($simpleUrlWithTraillingSlash), $fav->baseUrl($simpleUrlWithTraillingSlash));
-        $this->assertEquals(self::slash($simpleWithPort), $fav->baseUrl($simpleWithPort));
-        $this->assertEquals(self::slash($userWithoutPasswordUrl), $fav->baseUrl($userWithoutPasswordUrl));
-        $this->assertEquals(self::slash($userPasswordUrl), $fav->baseUrl($userPasswordUrl));
-        $this->assertEquals(self::slash($simpleUrl), $fav->baseUrl($urlWithUnusedInfo));
-        $this->assertEquals(self::slash($simpleUrl), $fav->baseUrl($urlWithPath, false));
-        $this->assertEquals(self::slash($urlWithPath), $fav->baseUrl($urlWithPath, true));
+        $this->assertEquals(self::slash($simpleUrl), $fav::baseUrl($simpleUrl));
+        $this->assertEquals(self::slash($simpleHttpsUrl), $fav::baseUrl($simpleHttpsUrl));
+        $this->assertEquals(self::slash($simpleUrlWithTraillingSlash), $fav::baseUrl($simpleUrlWithTraillingSlash));
+        $this->assertEquals(self::slash($simpleWithPort), $fav::baseUrl($simpleWithPort));
+        $this->assertEquals(self::slash($userWithoutPasswordUrl), $fav::baseUrl($userWithoutPasswordUrl));
+        $this->assertEquals(self::slash($userPasswordUrl), $fav::baseUrl($userPasswordUrl));
+        $this->assertEquals(self::slash($simpleUrl), $fav::baseUrl($urlWithUnusedInfo));
+        $this->assertEquals(self::slash($simpleUrl), $fav::baseUrl($urlWithPath, false));
+        $this->assertEquals(self::slash($urlWithPath), $fav::baseUrl($urlWithPath, true));
     }
 
     /**


### PR DESCRIPTION
Changes the dynamic method call to a static call, because the method is static too.